### PR TITLE
Add backdrop in restpg

### DIFF
--- a/src/partials/book-table.html
+++ b/src/partials/book-table.html
@@ -64,3 +64,4 @@
     </form>
   </div>
 </div>
+<div class="overlay js-overlay-modal"></div>

--- a/src/partials/room-price.html
+++ b/src/partials/room-price.html
@@ -41,3 +41,4 @@
     </form>
   </div>
 </div>
+<div class="overlay js-overlay-modal"></div>

--- a/src/sass/components/_modal.scss
+++ b/src/sass/components/_modal.scss
@@ -215,4 +215,5 @@ select::-ms-expand {
    background-color: rgba(0, 0, 0, .5);
    z-index: 20;
    transition: .3s all;
+   pointer-events: none;
 }


### PR DESCRIPTION
1. Додав блок з класом overlay до модалок заказ столику та ціни на номери;
2. Додав властивість pointer-events: none; до класу  overlay, щоб не клікалось поза модалкою. В ДЗ це було плюсом. В ТЗ до проєкту це не описаною, вважаю так буде краще. Нам би ще скролл відключити було б ще краще.